### PR TITLE
Event Handlers Signature Standardized

### DIFF
--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -102,7 +102,7 @@ class EventManager implements EventManagerInterface
      * @param callable $callback The callback to wrap.
      * @return \Closure The wrapper.
      */
-    protected function _createCallbackWrapper($name, &$callback)
+    protected function _createCallbackWrapper($name, $callback)
     {
         $me = $this;
         return function() use ($name, &$callback, &$me) {

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -26,12 +26,21 @@ class EventManager implements EventManagerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @since [*next-version*]
      */
     public function attach($event, $callback, $priority = 10)
     {
         $eventObject   = $this->normalizeEvent($event);
         $numArgsToPass = $this->getCallableNumParams($callback);
-        \add_filter($eventObject->getName(), $callback, $priority, $numArgsToPass + 1);
+        $this->_addHook($name, $callback, $priority, 1);
+    }
+
+    protected function _addHook($name, $handler, $priority = 10, $numArgs = 1)
+    {
+        \add_filter($name, $handler, $priority, $numArgs);
+
+        return $this;
     }
 
     /**

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -67,7 +67,7 @@ class EventManager implements EventManagerInterface
     }
 
     /**
-     * Gets a cached callback wrapper, creating it if no wrapper exists yet for given parameters.
+     * Gets a cached event callback wrapper, creating it if no wrapper exists.
      *
      * @since [*next-version*]
      *
@@ -79,7 +79,7 @@ class EventManager implements EventManagerInterface
      */
     protected function _getCallbackWrapper($name, $callback)
     {
-        $cbHash = $this->_hashCallable($callback);
+        $cbHash = $this->_hashEventHandler($name, $callback);
         if (!isset($this->callbackWrappers[$cbHash])) {
             $this->callbackWrappers[$cbHash] = $this->_createCallbackWrapper($name, $callback);
         }
@@ -260,6 +260,24 @@ class EventManager implements EventManagerInterface
         return is_array($callable) ?
             new \ReflectionMethod($callable[0], $callable[1]) :
             new \ReflectionFunction($callable);
+    }
+
+    /**
+     * Hashes an event name / event handler pair.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $name The name of the event.
+     * @param callable $handler The handler of the event.
+     *
+     * @return string The hash of the pair.
+     */
+    protected function _hashEventHandler($name, $handler)
+    {
+        $handlerHash = $this->_hashCallable($handler);
+        $pair = $name.'|'.$handlerHash;
+
+        return $this->_hashScalar($pair);
     }
 
     /**

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -63,6 +63,8 @@ class EventManager implements EventManagerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @since [*next-version*]
      */
     public function trigger($event, $target = null, $argv = array())
     {
@@ -71,7 +73,24 @@ class EventManager implements EventManagerInterface
             : $argv;
         array_push($args, $target);
         $eventObject = $this->normalizeEvent($event);
-        \apply_filters_ref_array($eventObject->getName(), $args);
+
+        return $this->_runHandlers($eventObject->getName(), $args);
+    }
+
+    /**
+     * Runs all handlers for the specified hook.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $name Name of the hook to run handlers for.
+     * @param array $args Args to pass to the handler.
+     * @return mixed The result returned by the handlers.
+     */
+    protected function _runHandlers($name, array $args = array())
+    {
+        array_unshift($args, $name);
+        $result = call_user_func_array('apply_filters', $args);
+        return $result;
     }
 
     /**

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -18,7 +18,18 @@ use Psr\EventManager\EventManagerInterface;
 class EventManager implements EventManagerInterface
 {
     /**
+     * A cache of callback wrappers, by hash.
+     *
+     * @since [*next-version*]
+     *
+     * @var callable[]
+     */
+    protected $callbackWrappers = array();
+
+    /**
      * Constructs a new instance.
+     *
+     * @since [*next-version*]
      */
     public function __construct()
     {
@@ -29,18 +40,83 @@ class EventManager implements EventManagerInterface
      *
      * @since [*next-version*]
      */
-    public function attach($event, $callback, $priority = 10)
+    public function attach($name, $callback, $priority = 10)
     {
-        $eventObject   = $this->normalizeEvent($event);
-        $numArgsToPass = $this->getCallableNumParams($callback);
-        $this->_addHook($name, $callback, $priority, 1);
+        $handler = $this->_getCallbackWrapper($name, $callback);
+        $this->_addHook($name, $handler, $priority, 1);
     }
 
+    /**
+     * Adds a hook to the environment.
+     *
+     * @since [*next-version*]
+     *
+     * @see add_filter()
+     *
+     * @param string $name
+     * @param callable $handler
+     * @param int $priority
+     * @param int $numArgs
+     * @return EventManager This instance.
+     */
     protected function _addHook($name, $handler, $priority = 10, $numArgs = 1)
     {
         \add_filter($name, $handler, $priority, $numArgs);
 
         return $this;
+    }
+
+    /**
+     * Gets a cached callback wrapper, creating it if no wrapper exists yet for given parameters.
+     *
+     * @since [*next-version*]
+     *
+     * @see _createCallbackWrapper()
+     *
+     * @param string $name
+     * @param callable $callback
+     * @return \Closure
+     */
+    protected function _getCallbackWrapper($name, $callback)
+    {
+        $cbHash = $this->_hashCallable($callback);
+        if (!isset($this->callbackWrappers[$cbHash])) {
+            $this->callbackWrappers[$cbHash] = $this->_createCallbackWrapper($name, $callback);
+        }
+
+        return $this->callbackWrappers[$cbHash];
+    }
+
+    /**
+     * Creates a wrapper for an event handler, containing and replacing it.
+     *
+     * If the wrapper receives an {@see EventInterface}, it will use that and assume it was
+     * triggered or normalized earlier by the event manager.
+     * Otherwise, it will assume that regular parameters are passed, such as
+     * what WordPress does, and will create an event object from that.
+     * Also allows events to stop propagation.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $name The name of the event, for which a wrapper is created.
+     * @param callable $callback The callback to wrap.
+     * @return \Closure The wrapper.
+     */
+    protected function _createCallbackWrapper($name, &$callback)
+    {
+        $me = $this;
+        return function() use ($name, &$callback, &$me) {
+            $args = \func_get_args();
+            $event = \count($args) && $args[0] instanceof EventInterface
+                    ? $args[0]
+                    : $me->createEvent($name, $args);
+            /* @var $event \Dhii\WpEvents\Event */
+            if (!$event->isPropagationStopped()) {
+                \call_user_func_array($callback, array($event));
+            }
+
+            return $event;
+        };
     }
 
     /**
@@ -145,6 +221,22 @@ class EventManager implements EventManagerInterface
     }
 
     /**
+     * Creates a new event instance.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $name        The event name.
+     * @param array  $params      The event parameters.
+     * @param mixed  $target      The target object. Used for context.
+     * @param bool   $propagation True to propagate the event, false to not.
+     * @return Event The new event.
+     */
+    public function createEvent($name, $params = array(), $target = null, $propagation = true)
+    {
+        return $this->_createEvent($name, $params, $target, $propagation);
+    }
+
+    /**
      * Gets the number of parameters for a callable.
      *
      * @param callable $callable The callable.
@@ -168,5 +260,86 @@ class EventManager implements EventManagerInterface
         return is_array($callable) ?
             new \ReflectionMethod($callable[0], $callable[1]) :
             new \ReflectionFunction($callable);
+    }
+
+    /**
+     * Computes a hash of a given callable.
+     *
+     * @since [*next-version*]
+     *
+     * @param callable $callable The callable to hash.
+     * @return string A hash of the callable.
+     * @throws \InvalidArgumentException If not a valid callable.
+     */
+    protected function _hashCallable($callable)
+    {
+        if (is_object($callable)) {
+            return $this->_hashObject($callable);
+        }
+
+        if (is_array($callable)) {
+            return $this->_hashArray($callable);
+        }
+
+        throw new \InvalidArgumentException('Could not hash: not a valid callback');
+    }
+
+    /**
+     * Computes a hash of the array.
+     *
+     * Accounts for nested arrays.
+     *
+     * @since [*next-version*]
+     *
+     * @param array $array The array to hash.
+     * @return string A hash of the array.
+     */
+    protected function _hashArray(array $array)
+    {
+        $itemHashes = array();
+        foreach ($array as $_idx => $_item) {
+            if (is_array($_item)) {
+                $itemHashes[$_idx] = $this->_hashArray($_item);
+            } elseif (is_object($_item)) {
+                $itemHashes[$_idx] = $this->_hashObject($_item);
+            } elseif (is_resource($_item)) {
+                $itemHashes[$_idx] = (string) $_item;
+            } else {
+                $itemHashes[$_idx] = $_item;
+            }
+        }
+
+        $itemHashes = serialize($itemHashes);
+
+        return $this->_hashScalar($itemHashes);
+    }
+
+    /**
+     * Computes a hash of an object.
+     *
+     * The same object will always have the same hash.
+     * Different identical objects will produce different results.
+     *
+     * @since [*next-version*]
+     *
+     * @param object $object The object to hash.
+     * @return string A hash of the object.
+     */
+    protected function _hashObject($object)
+    {
+        return \spl_object_hash($object);
+    }
+
+    /**
+     * Computes a hash of a scalar value.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|int|float|bool $value The value to hash.
+     * @return string A hash of the scalar value.
+     */
+    protected function _hashScalar($value)
+    {
+        return \sha1($value);
     }
 }

--- a/test/functional/EventManagerTest.php
+++ b/test/functional/EventManagerTest.php
@@ -74,20 +74,24 @@ class EventManagerTest extends TestCase
      */
     public function testAttach()
     {
-        $subject = $this->createInstance();
-        $name = 'myevent';
-        $priority = 10;
+        $subject = Mockery::mock(static::TEST_SUBJECT_CLASS_NAME)
+                ->makePartial()
+                ->shouldAllowMockingProtectedMethods();
+        $name = uniqid('event');
+        $priority = (int) rand(1, 100);
         $output = uniqid('Hello Test!');
         $callback = function() use ($output) {
             echo $output;
         };
-        array(
-            'args'      => array(),
-            'times'     => 1,
-            'return'    => Mockery::type('Psr\\EventManager\\EventInterface')
-        );
 
-        WP_Mock::expectFilterAdded($name, $callback, $priority);
+        $subject->shouldReceive('_addHook')
+                ->once()
+                ->withArgs(array(
+                    $name,
+                    Mockery::type('callable'),
+                    $priority,
+                    1
+                ));
 
         $subject->attach($name, $callback, $priority);
     }

--- a/test/functional/EventManagerTest.php
+++ b/test/functional/EventManagerTest.php
@@ -201,4 +201,38 @@ class EventManagerTest extends TestCase
 
         $this->assertEquals($return, $result, 'Handlers were not run correctly');
     }
+
+    /**
+     * Tests whether a callback wrapper for a handler can be created correctly.
+     *
+     * @since [*next-version*]
+     */
+    public function testCreateCallbackWrapper()
+    {
+        $subject = $this->createInstance();
+        $me = $this;
+        $name = \uniqid('event');
+        $params = array(
+            'apple',
+            'orange',
+            'banana',
+        );
+
+        $handler = function() use (&$me, $params) {
+            $args = func_get_args();
+            $me->assertCount(1, $args, 'Wrong number of arguments received by handler');
+
+            $event = $args[0];
+            $me->assertInstanceOf('Psr\\EventManager\\EventInterface', $event, 'Event received by handler is not a valid event');
+            /* @var $event \Psr\EventManager\EventInterface */
+
+            $eventParams = $event->getParams();
+            $me->assertEquals($params, $eventParams, 'Parameters retrieved in event handler are not what was passed');
+        };
+
+        $wrapper = $subject->this()->_createCallbackWrapper($name, $handler);
+        $this->assertInstanceOf('Closure', $wrapper, 'Wrapper is not a valid closure');
+
+        \call_user_func_array($wrapper, $params);
+    }
 }

--- a/test/functional/EventManagerTest.php
+++ b/test/functional/EventManagerTest.php
@@ -257,4 +257,36 @@ class EventManagerTest extends TestCase
         $result = \call_user_func_array($wrapper2, array($result));
         $result = \call_user_func_array($wrapper3, array($result));
     }
+
+    /**
+     * Tests whether callback wrapper cache works correctly.
+     *
+     * The cache should return the same wrapper for the same name/callback pair.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetCallbackWrapper()
+    {
+        $subject = $this->createInstance();
+        $name = \uniqid('event');
+        $otherName = \uniqid('other-event');
+
+        $handler1 = function() {
+            echo 'Just do something';
+        };
+
+        $handler2 = function($event) {
+            echo 'Just do something else';
+        };
+
+        $wrapper1 = $subject->this()->_getCallbackWrapper($name, $handler1);
+        $wrapper2 = $subject->this()->_getCallbackWrapper($name, $handler1);
+        $this->assertSame($wrapper1, $wrapper2, 'Different wrappers returned for same handler');
+
+        $wrapper3 = $subject->this()->_getCallbackWrapper($name, $handler2);
+        $this->assertNotSame($wrapper2, $wrapper3, 'Same wrapper returned for different handlers');
+
+        $wrapper4 = $subject->this()->_getCallbackWrapper($otherName, $handler1);
+        $this->assertNotSame($wrapper1, $wrapper4, 'Same wrapper returned for same handler but different event name');
+    }
 }

--- a/test/functional/EventManagerTest.php
+++ b/test/functional/EventManagerTest.php
@@ -117,4 +117,59 @@ class EventManagerTest extends TestCase
         WP_Mock::expectFilterAdded($name, $callback, $priority, $numArgs);
         $subject->this()->_addHook($name, $callback, $priority, $numArgs);
     }
+
+    /**
+     * Tests whether the `trigger()` method correctly triggers events.
+     *
+     * @since [*next-version*]
+     */
+    public function testTrigger()
+    {
+        $subject = Mockery::mock(static::TEST_SUBJECT_CLASS_NAME)
+                ->makePartial()
+                ->shouldAllowMockingProtectedMethods();
+        $name = uniqid('event');
+        $target = null;
+        $args = array(
+            'apple',
+            'banana',
+            'orange'
+        );
+
+        $subject->shouldReceive('_runHandlers')
+                ->once()
+                ->withArgs(array(
+                    $name,
+                    Mockery::type('array'),
+                ));
+
+        $subject->trigger($name, $target, $args);
+    }
+
+    /**
+     * Verifies that `_runHandlers()` executes a given action correctly.
+     *
+     * @since [*next-version*]
+     */
+    public function testRunHandlers()
+    {
+        $subject = $this->createInstance();
+        $name = uniqid('event');
+        $target = null;
+        $primary = 'apple';
+        $secondary = 'banana';
+        $tertiary = 'kiwi';
+        $args = array(
+            $primary,
+        );
+        $return = 'pineapple';
+
+        WP_Mock::onFilter($name)
+                ->with($args)
+                ->reply($return);
+
+        $result = $subject->this()->_runHandlers($name, $args, $target);
+
+        $this->assertEquals($return, $result, 'Handlers were not run correctly');
+    }
 }

--- a/test/functional/EventManagerTest.php
+++ b/test/functional/EventManagerTest.php
@@ -95,4 +95,26 @@ class EventManagerTest extends TestCase
 
         $subject->attach($name, $callback, $priority);
     }
+
+    /**
+     * Tests that the `_addHook()` method runs as expected.
+     *
+     * It must add a specific filter, depending on how it is called.
+     *
+     * @since [*next-version*]
+     */
+    public function testAddHook()
+    {
+        $subject = $this->createInstance();
+        $name = uniqid('event');
+        $priority = (int) rand(1, 100);
+        $output = uniqid('Hello Test!');
+        $callback = function() use ($output) {
+            echo $output;
+        };
+        $numArgs = (int) rand(1, 10);
+
+        WP_Mock::expectFilterAdded($name, $callback, $priority, $numArgs);
+        $subject->this()->_addHook($name, $callback, $priority, $numArgs);
+    }
 }


### PR DESCRIPTION
All event handlers will now receive the same one and only one argument: an instance of `EventInterface` that represents the event.