### PR TITLE
Improves Event Cache Clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+## [0.2] 2017-01-08
+### Fixed
+- Reflection parameter detection in `EventManager`.
+
+## [0.1] 2016-07-07
+Initial release.
+### Added
+- `EventManager` and `Event` classes.

--- a/src/AbstractNormalizedEventManager.php
+++ b/src/AbstractNormalizedEventManager.php
@@ -219,7 +219,7 @@ abstract class AbstractNormalizedEventManager extends AbstractWpEventManager
         return function () use ($name, &$callback, &$me) {
             /* @var $me AbstractNormalizedEventManager */
 
-            $args  = \func_get_args();
+            $args    = \func_get_args();
             $isEvent = \count($args) && $args[0] instanceof EventInterface;
 
             $event = $isEvent

--- a/src/AbstractNormalizedEventManager.php
+++ b/src/AbstractNormalizedEventManager.php
@@ -105,8 +105,6 @@ abstract class AbstractNormalizedEventManager extends AbstractWpEventManager
         if (!$this->_hasCachedEvent($name)) {
             // Create event instance if it does not exist
             $event = $this->_createCachedEvent($name);
-            // Register handler to delete the event instance at the end of the chain
-            $this->_registerClearCacheHandler($event);
         }
 
         $event = $this->eventCache[$name];
@@ -144,49 +142,6 @@ abstract class AbstractNormalizedEventManager extends AbstractWpEventManager
         $this->_removeCachedEvent($name);
 
         return $this;
-    }
-
-    /**
-     * Registers a clear cache handler.
-     *
-     * @since [*next-version*]
-     *
-     * @param EventInterface $event The event instance to clear from cache.
-     *
-     * @return $this This instance.
-     */
-    protected function _registerClearCacheHandler(EventInterface $event)
-    {
-        $priority = static::CACHE_CLEAR_HANDLER_PRIORITY;
-        $callback = $this->_createClearCacheHandler($event);
-
-        $this->_addHook($event->getName(), $callback, $priority);
-
-        return $callback;
-    }
-
-    /**
-     * Creates a cache clear handler.
-     *
-     * @since [*next-version*]
-     *
-     * @param EventInterface $event The event instance to be cleared from cache by the handler.
-     *
-     * @return \callable The created handler.
-     */
-    protected function _createClearCacheHandler(EventInterface $event)
-    {
-        $me       = $this;
-        $priority = static::CACHE_CLEAR_HANDLER_PRIORITY;
-
-        $callback = function($value) use ($me, $event, &$callback, $priority) {
-            $me->_zRemoveCachedEvent($event->getName());
-            $me->_zDetach($event, $callback, $priority);
-
-            return $value;
-        };
-
-        return $callback;
     }
 
     /**

--- a/src/AbstractNormalizedEventManager.php
+++ b/src/AbstractNormalizedEventManager.php
@@ -13,11 +13,18 @@ use Psr\EventManager\EventInterface;
 abstract class AbstractNormalizedEventManager extends AbstractWpEventManager
 {
     /**
+     * The hook on to which the cache clear handler is hooked.
+     *
+     * @since [*next-version*]
+     */
+    const CACHE_CLEAR_HANDLER_EVENT = 'all';
+
+    /**
      * The priority of the cache clear handler.
      *
      * @since [*next-version*]
      */
-    const CACHE_CLEAR_HANDLER_PRIORITY = PHP_INT_MAX;
+    const CACHE_CLEAR_HANDLER_PRIORITY = 0;
 
     /**
      * A cache of event instances.
@@ -32,17 +39,33 @@ abstract class AbstractNormalizedEventManager extends AbstractWpEventManager
     protected $eventCache;
 
     /**
-     * Detaches a listener from an event.
+     * Registers the event cache clear handler.
      *
-     * @param string $event the event to attach too
-     * @param callable $callback a callable function
-     * @param int $priority The priority that was used to initially register the listener.
+     * @since [*next-version*]
      *
-     * @return bool True on success, false on failure
+     * @return $this
      */
-    public function _zDetach($event, $callback, $priority = self::DEFAULT_PRIORITY)
+    protected function _registerEventCacheClearHandler()
     {
-        $this->_detach($event, $callback, $priority);
+        $this->_addHook(
+            static::CACHE_CLEAR_HANDLER_EVENT,
+            array($this, '_zRemoveCachedEventHandler'),
+            static::CACHE_CLEAR_HANDLER_PRIORITY
+        );
+
+        return $this;
+    }
+
+    /**
+     * Clears the cached event for a specific event name.
+     *
+     * @param string $name The name of the hook.
+     *
+     * @return $this
+     */
+    public function _zRemoveCachedEventHandler($name)
+    {
+        $this->_removeCachedEvent($name);
 
         return $this;
     }

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -27,6 +27,7 @@ class EventManager extends AbstractWrapperCachingEventManager implements EventMa
     public function __construct()
     {
         $this->_construct();
+        $this->_registerEventCacheClearHandler();
     }
 
     /**

--- a/test/functional/AbstractNormalizedEventManagerTest.php
+++ b/test/functional/AbstractNormalizedEventManagerTest.php
@@ -178,7 +178,7 @@ class AbstractNormalizedEventManagerTest extends TestCase
      *
      * @since [*next-version*]
      */
-    public function testClearCacheHandler()
+    public function testRemoveCachedEventHandler()
     {
         $subject = Mockery::mock(static::TEST_SUBJECT_CLASSNAME)
             ->makePartial()
@@ -186,20 +186,15 @@ class AbstractNormalizedEventManagerTest extends TestCase
         ;
 
         $name = uniqid('event');
-        $event = $this->createEventMock($name);
-        $priority = PHP_INT_MAX;
-        $callback = $this->reflect($subject)->_createClearCacheHandler($event);
 
-        $subject->shouldReceive('_zDetach')
+        $subject->shouldReceive('_removeCachedEvent')
             ->once()
             ->withArgs(array(
-                $event,
-                Mockery::type('callable'),
-                $priority
+                $name
             ))
         ;
 
-        $callback($event);
+        $this->reflect($subject)->_zRemoveCachedEventHandler($name);
     }
 
     /**
@@ -207,18 +202,20 @@ class AbstractNormalizedEventManagerTest extends TestCase
      *
      * @since [*next-version*]
      */
-    public function testRegisterClearCacheHandler()
+    public function testRegisterEventCacheClearHandler()
     {
         $subject = $this->createInstance();
 
         $name = uniqid('event');
         $event = $this->createEventMock($name);
 
-        $callback = $subject->this()->_createClearCacheHandler($event);
+        $hook     = AbstractNormalizedEventManager::CACHE_CLEAR_HANDLER_EVENT;
+        $callback = array($subject, '_zRemoveCachedEventHandler');
+        $priority = AbstractNormalizedEventManager::CACHE_CLEAR_HANDLER_PRIORITY;
 
-        WP_Mock::expectFilterAdded($name, $callback, PHP_INT_MAX, 1);
+        WP_Mock::expectFilterAdded($hook, $callback, $priority, 1);
 
-        $subject->this()->_registerClearCacheHandler($event);
+        $subject->this()->_registerEventCacheClearHandler($event);
     }
 
     /**


### PR DESCRIPTION
Attempts to incorporate a solution for #12 

----

This new mechanism registers only a single handle registered on the WordPress `all` hook, which is invoked before any handlers for any hook trigger. The handler receives the name of the triggered hook as parameter and uses that to clear any event instance from cache that might have been created during a prior invocation of that hook.